### PR TITLE
Refresh token frontside and backend done

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,11 +1,30 @@
-import { createContext, useState } from "react";
-import type { Auth, Children } from "../types/user";
+import { createContext, useEffect, useState } from "react";
+import type { Auth, Children, UserPayload } from "../types/user";
 
 export const AuthContext = createContext<null | Auth>(null);
 
 export const AuthProvider = ({ children }: Children) => {
   const [isLogged, setIsLogged] = useState(false);
+  const [user, setUser] = useState<UserPayload | null>(null);
+  useEffect(() => {
+    fetch("http://localhost:3310/api/refresh-token", {
+      credentials: "include",
+    })
+      .then((res) => {
+        if (res.ok) {
+          setIsLogged(true);
+          return res.json();
+        }
+      })
+      .then((data) => {
+        if (data) {
+          setUser(data);
+        }
+      });
+  }, []);
   return (
-    <AuthContext value={{ isLogged, setIsLogged }}>{children}</AuthContext>
+    <AuthContext value={{ isLogged, setIsLogged, user, setUser }}>
+      {children}
+    </AuthContext>
   );
 };

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -3,7 +3,16 @@ import type { ReactNode } from "react";
 export interface Children {
   children: ReactNode;
 }
+export interface UserPayload {
+  id: number;
+  firstname: string;
+  lastname: string;
+  email: string;
+  isAdmin: boolean;
+}
 export interface Auth {
   isLogged: boolean;
   setIsLogged: (value: boolean) => void;
+  user: UserPayload | null;
+  setUser: (value: UserPayload | null) => void;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2471,6 +2471,16 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT"
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -3643,6 +3653,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8733,6 +8765,7 @@
       "name": "@js-monorepo/server",
       "dependencies": {
         "argon2": "^0.43.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -8741,6 +8774,7 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^9.6.0",
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.1",
         "@types/jest": "^29.5.14",

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "argon2": "^0.43.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",
     "@types/jest": "^29.5.14",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -25,7 +25,8 @@ if (process.env.CLIENT_URL != null) {
 }
 
 // If you need to allow extra origins, you can add something like this:
-
+import cookieParser from "cookie-parser";
+app.use(cookieParser());
 /*
 app.use(
   cors({

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -27,6 +27,7 @@ router.post(
 
 router.post("/api/login", auth.login);
 router.post("/api/logout", auth.logout);
+router.get("/api/refresh-token", auth.refreshToken);
 router.get("/api/user", userActions.browse);
 router.get("/api/artist", userActions.browseArtists);
 

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -1,6 +1,6 @@
 import argon2 from "argon2";
 import type { RequestHandler } from "express";
-import jwt from "jsonwebtoken";
+import jwt, { type JwtPayload } from "jsonwebtoken";
 import userRepository from "../modules/user/userRepository";
 
 const hashedPassword: RequestHandler = async (req, res, next) => {
@@ -58,4 +58,36 @@ const logout: RequestHandler = (req, res) => {
     res.sendStatus(500);
   }
 };
-export default { hashedPassword, login, logout };
+
+const refreshToken: RequestHandler = (req, res, next) => {
+  try {
+    const token = req.cookies.token;
+
+    if (!token) {
+      throw new Error("A token must be provided");
+    }
+    const secretKey = process.env.APP_SECRET;
+    if (!secretKey) {
+      throw new Error("A secret key must be provided");
+    }
+
+    const decoded = jwt.verify(token, secretKey);
+    if (decoded) {
+      const payload = decoded as JwtPayload;
+      const newToken = jwt.sign({ id: payload.id }, secretKey, {
+        expiresIn: "1d",
+      });
+
+      res.cookie("token", newToken, {
+        httpOnly: true,
+        secure: false,
+      });
+      res.status(200).send(payload);
+    } else {
+      res.sendStatus(403);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+export default { hashedPassword, login, logout, refreshToken };


### PR DESCRIPTION
### **Summary of Changes**

- Implemented full session management with refresh token support

- Added functionality on both client and server to handle user authentication, token renewal, and cookie parsing

- Updated dependencies to support these features

### **Details**

1.  Client-side (Authentication Context)

- Extended AuthContext to manage user and setUser states

- Added useEffect to auto-fetch the user session from /api/refresh-token

- Created a UserPayload interface to define user data shape

2.  Server-side (Session Management)

- Added a new POST /api/refresh-token route to issue fresh tokens

- refreshToken() function validates the current token, generates a new one, and sends it via HTTP-only cookie

### **Dependency Updates**

- Installed cookie-parser and its types

- Integrated cookie-parser into Express to parse cookies for auth management
