### PR TITLE
CRUD backend for artwork, delete and readbyid

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -121,7 +121,7 @@ user_account_id INT NOT NULL,
 artwork_id INT NOT NULL,
 PRIMARY KEY (user_account_id, artwork_id),
 FOREIGN KEY (user_account_id) REFERENCES user_account(id),
-FOREIGN KEY (artwork_id) REFERENCES artwork(id)
+FOREIGN KEY (artwork_id) REFERENCES artwork(id) ON DELETE CASCADE
 );
 INSERT INTO favorite (user_account_id, artwork_id)
 VALUES
@@ -137,7 +137,7 @@ means_of_payment VARCHAR(55) NOT NULL,
 payment_validated BOOLEAN DEFAULT FALSE,
 PRIMARY KEY (user_account_id, artwork_id),
 FOREIGN KEY (user_account_id) REFERENCES user_account(id),
-FOREIGN KEY (artwork_id) REFERENCES artwork(id)
+FOREIGN KEY (artwork_id) REFERENCES artwork(id) ON DELETE CASCADE
 );
 INSERT INTO purchase (user_account_id, artwork_id, means_of_payment, payment_validated)
 VALUES

--- a/server/src/modules/artwork/artworkActions.ts
+++ b/server/src/modules/artwork/artworkActions.ts
@@ -34,6 +34,40 @@ const readUserAccount: RequestHandler = async (req, res, next) => {
   }
 };
 
+const readArtworkUserById: RequestHandler = async (req, res, next) => {
+  try {
+    const artwork_id = Number(req.params.artworkId);
+    const user_account_id = Number(req.params.userId);
+    const result = await artworkRepository.readArtworkUserById(
+      user_account_id,
+      artwork_id,
+    );
+    if (!result) {
+      res.status(404).json("There is a problem on your reader by id");
+    } else {
+      res.json(result);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+const deleteArtwork: RequestHandler = async (req, res, next) => {
+  try {
+    const artworkId = Number(req.params.id);
+    if (!artworkId || artworkId <= 0) {
+      res.status(404).json("Cannot be null");
+    }
+    const deleteArtwork = await artworkRepository.delete(artworkId);
+    if (deleteArtwork === 0) {
+      res.status(404).json("Artwork not found");
+      return;
+    }
+    res.status(200).json("Artwork deleted");
+  } catch (err) {
+    next(err);
+  }
+};
 const browseCarouselArtworks: RequestHandler = async (req, res) => {
   try {
     const categoryName = req.params.categoryName;
@@ -53,4 +87,6 @@ export default {
   browse,
   readArtworkCategory,
   readUserAccount,
+  readArtworkUserById,
+  deleteArtwork,
 };

--- a/server/src/modules/artwork/artworkRepository.ts
+++ b/server/src/modules/artwork/artworkRepository.ts
@@ -1,5 +1,5 @@
 import type { Rows } from "../../../database/client";
-import databaseClient from "../../../database/client";
+import databaseClient, { type Result } from "../../../database/client";
 
 class ArtworkRepository {
   async readAll() {
@@ -16,12 +16,25 @@ class ArtworkRepository {
 
   async readUserAccount(id: number) {
     const [rows] = await databaseClient.query<Rows>(
-      "SELECT * from artwork WHERE user_account_id = TRUE",
+      "SELECT * from artwork WHERE user_account_id = ?",
       [id],
     );
     return rows;
   }
-
+  async readArtworkUserById(userId: number, artworkId: number) {
+    const [rows] = await databaseClient.query<Rows>(
+      "SELECT * FROM artwork WHERE user_account_id = ? AND artwork.id = ?",
+      [userId, artworkId],
+    );
+    return rows;
+  }
+  async delete(id: number) {
+    const [result] = await databaseClient.query<Result>(
+      "DELETE FROM artwork WHERE id = ?",
+      [id],
+    );
+    return result.affectedRows;
+  }
   async readCarouselArtwork(categoryName: string) {
     const [result] = await databaseClient.query<Rows>(
       `

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -34,7 +34,12 @@ router.get("/api/artist", userActions.browseArtists);
 /* ************************************************************************* */
 router.get("/api/artwork", artworkActions.browse);
 router.get("/api/artwork/artwork-category", artworkActions.readArtworkCategory);
-router.get("/api/artwork/:id", artworkActions.readUserAccount);
+router.get("/api/artist/:id/artworks", artworkActions.readUserAccount);
+router.get(
+  "/api/artist/:userId/artworks/:artworkId",
+  artworkActions.readArtworkUserById,
+);
+router.delete("/api/artworks/:id", artworkActions.deleteArtwork);
 
 router.get("/api/artist/:id", userActions.browseArtistArtworks);
 


### PR DESCRIPTION
### **Summary of Changes**

- Improved database integrity with cascade deletes

- Expanded artwork API functionality with new endpoints

- Extended the repository layer to support these features

### **Details**

1. Database Schema Update

> Added ON DELETE CASCADE to ensure related entries are automatically removed when an artwork is deleted (had problem in bruno)

2. API Enhancements

> Added new endpoint readArtworkUserById to fetch a specific artwork linked to a user

> Introduced deleteArtwork endpoint to allow artwork deletion by ID

> Implemented in artworkActions.ts and exposed via routing layer

3.  Repository Layer Extensions

> Created readArtworkUserById() and delete() methods in ArtworkRepository


4.  Router Updates

> Added new routes in router.ts

