### PR TITLE
feat: add readArtworkWithArtistById method to fetch artwork with arti…

### DIFF
--- a/server/src/modules/artwork/artworkActions.ts
+++ b/server/src/modules/artwork/artworkActions.ts
@@ -25,6 +25,21 @@ const readArtworkById: RequestHandler = async (req, res, next) => {
   }
 };
 
+const readArtworkWithArtistById: RequestHandler = async (req, res, next) => {
+  try {
+    const artworkId = Number(req.params.id);
+    const result = await artworkRepository.readArtworkWithArtistById(artworkId);
+
+    if (!result) {
+      res.status(404).json("Artwork not found");
+    } else {
+      res.json(result);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
 const readArtworkCategory: RequestHandler = async (req, res, next) => {
   try {
     const { categoryName } = req.params;
@@ -133,6 +148,7 @@ export default {
   browseCarouselArtworks,
   browse,
   readArtworkById,
+  readArtworkWithArtistById,
   readArtworkCategory,
   readUserAccount,
   edit,

--- a/server/src/modules/artwork/artworkRepository.ts
+++ b/server/src/modules/artwork/artworkRepository.ts
@@ -33,6 +33,21 @@ class ArtworkRepository {
     return result;
   }
 
+  async readArtworkWithArtistById(artworkId: number) {
+    const [rows] = await databaseClient.query<Rows>(
+      `SELECT 
+        artwork.*,
+        user_account.firstname AS artist_firstname,
+        user_account.lastname AS artist_lastname,
+        user_account.image AS artist_image
+      FROM artwork
+      JOIN user_account ON artwork.user_account_id = user_account.id
+      WHERE artwork.id = ?`,
+      [artworkId],
+    );
+    return rows;
+  }
+
   async readUserAccount(id: number) {
     const [rows] = await databaseClient.query<Rows>(
       "SELECT * from artwork WHERE user_account_id = ?",

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -35,6 +35,7 @@ router.get("/api/artist", userActions.browseArtists);
 router.get("/api/artwork", artworkActions.browse);
 router.get("/api/artwork/artwork-category", artworkActions.readArtworkCategory);
 router.get("/api/artwork/:id", artworkActions.readArtworkById);
+router.get("/api/artwork/:id/artist", artworkActions.readArtworkWithArtistById);
 router.put("/api/artwork/:id", artworkActions.edit);
 router.get("/api/artist/:id/artworks", artworkActions.readUserAccount);
 router.get(


### PR DESCRIPTION
# Feature: Retrieve Artwork with Artist Details

## Overview

This pull request adds backend functionality to fetch detailed artwork information along with the associated artist’s data. It includes a new handler, repository method, and routing update.

## New Endpoint for Artwork + Artist Details

- **Handler (`readArtworkWithArtistById`)**:  
  Implemented in `artworkActions.ts`, this handler:
  - Receives an artwork ID from the request parameters
  - Queries the repository for artwork details joined with artist information (e.g., artist name, image)
  - Returns the combined data or a 404 error if not found

- **Repository Method (`readArtworkWithArtistById`)**:  
  Added in `artworkRepository.ts`, this method:
  - Executes a database query joining artwork and artist tables
  - Returns detailed artwork info with artist data

## Router Update

- **New route added**:  
  `GET /api/artwork/:id/artist` mapped to `readArtworkWithArtistById`

## Integration

- Exported `readArtworkWithArtistById` in `artworkActions.ts` for router integration.

## Summary

This enhancement allows clients to retrieve rich artwork details along with artist info in a single API call, facilitating richer UI features.
