### PR TITLE
Fixbug - collection page -  Had to change route inside fetch

### DIFF
--- a/client/src/pages/CollectionPage/CollectionPage.tsx
+++ b/client/src/pages/CollectionPage/CollectionPage.tsx
@@ -9,7 +9,7 @@ function CollectionPage() {
   const { isLogged } = useAuth();
 
   useEffect(() => {
-    fetch(`http://localhost:3310/api/artwork/${id}`, {
+    fetch(`http://localhost:3310/api/artist/${id}/artworks`, {
       credentials: "include",
     })
       .then((res) => res.json())


### PR DESCRIPTION
### **Detail**
- Changed the API endpoint in the `fetch` call from `http://localhost:3310/api/artwork/${id}` to `http://localhost:3310/api/artist/${id}/artworks` to retrieve artworks associated with a specific artist.