### PR TITLE
US- 33 - Feat - Admin delete artwork 

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -29,7 +29,9 @@ VALUES
 ", TRUE, FALSE, TRUE),
 ("Sema", "Martin", "sema@example.com", "$argon2i$v=19$m=16,t=2,p=1$WlExTEVQNFpnSDFnbWFDSQ$H7cDIOY5G3T+cd/tQFYt+w", "7 allée des Cyprès", "Toulouse", "31000", "France", "http://localhost:3310/sema-martin.webp", "Dessin = ma passion. Sema Martin est une artiste dont le trait délicat et précis donne vie à des univers empreints de poésie. Inspirée par la nature et les émotions humaines, elle réalise des dessins qui racontent des histoires et suscitent l'imaginaire. Son style, à la fois doux et expressif, séduit par sa capacité à transmettre des sentiments profonds à travers la simplicité du crayon.
 ", TRUE, FALSE, TRUE),
-("Gisèle", "Thomas", "gisele@example.com", "$argon2i$v=19$m=16,t=2,p=1$WlExTEVQNFpnSDFnbWFDSQ$H7cDIOY5G3T+cd/tQFYt+w", "3 impasse des Érables", "Bordeaux", "33000", "France", NULL, NULL, FALSE, FALSE, TRUE);
+("Gisèle", "Thomas", "gisele@example.com", "$argon2i$v=19$m=16,t=2,p=1$WlExTEVQNFpnSDFnbWFDSQ$H7cDIOY5G3T+cd/tQFYt+w", "3 impasse des Érables", "Bordeaux", "33000", "France", NULL, NULL, FALSE, FALSE, TRUE),
+("Admin", "User", "admin@creanova.com", "$argon2i$v=19$m=16,t=2,p=1$WlExTEVQNFpnSDFnbWFDSQ$H7cDIOY5G3T+cd/tQFYt+w", "1 rue de l'Admin", "Paris", "75000", "France", NULL, NULL, FALSE, TRUE, TRUE);
+
 
 
 CREATE TABLE artwork (

--- a/server/src/modules/admin/adminActions.ts
+++ b/server/src/modules/admin/adminActions.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from "express";
+import adminRepository from "./adminRepository";
+
+const browseArtworks: RequestHandler = async (req, res, next) => {
+  try {
+    const artworks = await adminRepository.readAllArtworks();
+    res.json(artworks);
+  } catch (err) {
+    next(err);
+  }
+};
+
+const deleteArtwork: RequestHandler = async (req, res, next) => {
+  try {
+    const artworkId = Number(req.params.id);
+    if (!artworkId || artworkId <= 0) {
+      res.status(404).json("Cannot be null");
+    }
+    const deleteArtwork = await adminRepository.deleteArtwork(artworkId);
+    if (deleteArtwork === 0) {
+      res.status(404).json("Artwork not found");
+      return;
+    }
+    res.status(200).json("Artwork deleted");
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default { browseArtworks, deleteArtwork };

--- a/server/src/modules/admin/adminRepository.ts
+++ b/server/src/modules/admin/adminRepository.ts
@@ -1,0 +1,47 @@
+import databaseClient, {
+  type Result,
+  type Rows,
+} from "../../../database/client";
+
+class AdminRepository {
+  async readAllUsers() {
+    const [rows] = await databaseClient.query<Rows>(`
+        SELECT * FROM user_account`);
+    return rows;
+  }
+  async readAllArtworks() {
+    const [rows] = await databaseClient.query<Rows>(`
+        SELECT * FROM artwork`);
+    return rows;
+  }
+  async deleteArtwork(id: number) {
+    const [result] = await databaseClient.query<Result>(
+      `
+        DELETE FROM artwork WHERE id = ?`,
+      [id],
+    );
+    return result.affectedRows;
+  }
+  async readAllCategories() {
+    const [rows] = await databaseClient.query<Rows>(`
+        SELECT * FROM category`);
+    return rows;
+  }
+  async readAllPurchases() {
+    const [rows] = await databaseClient.query<Rows>(`
+        SELECT * FROM purchase`);
+    return rows;
+  }
+  async readAllNews() {
+    const [rows] = await databaseClient.query<Rows>(`
+        SELECT * FROM news`);
+    return rows;
+  }
+  async readAllEvents() {
+    const [rows] = await databaseClient.query<Rows>(`
+        SELECT * FROM event`);
+    return rows;
+  }
+}
+
+export default new AdminRepository();

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -6,12 +6,14 @@ const router = express.Router();
 // Define Your API Routes Here
 /* ************************************************************************* */
 
+import adminActions from "./modules/admin/adminActions";
 // Define item-related routes
 import artworkActions from "./modules/artwork/artworkActions";
 import favoriteActions from "./modules/favorite/favoriteActions";
 import itemActions from "./modules/item/itemActions";
 import purchaseActions from "./modules/purchase/purchaseActions";
 import userActions from "./modules/user/userActions";
+import admin from "./utils/admin";
 import auth from "./utils/auth";
 import validation from "./utils/validation";
 
@@ -75,5 +77,12 @@ router.post(
 router.post("/api/favorite", favoriteActions.addFavorite);
 router.get("/api/user/:userId/favorite", favoriteActions.favoriteArtwork);
 router.get("/api/favorite", favoriteActions.browse);
+/* ************************************************************************* */
+router.delete(
+  "/api/admin/artwork/:id",
+  auth.authenticateUser,
+  admin.adminAuth,
+  adminActions.deleteArtwork,
+);
 
 export default router;

--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -4,6 +4,13 @@ export type {};
 declare global {
   namespace Express {
     export interface Request {
+      user?: {
+        id: number;
+        is_admin: boolean;
+        email: string;
+        firstname: string;
+        lastname: string;
+      };
       /* ************************************************************************* */
       // Add your custom properties here, for example:
       //

--- a/server/src/utils/admin.ts
+++ b/server/src/utils/admin.ts
@@ -1,0 +1,11 @@
+import type { RequestHandler } from "express";
+
+const adminAuth: RequestHandler = (req, res, next) => {
+  if (req.user?.is_admin) {
+    return next();
+  }
+  res.status(403).json("Admin access required");
+  return;
+};
+
+export default { adminAuth };

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -106,6 +106,17 @@ const authenticateUser: RequestHandler = (req, res, next) => {
 
     const decoded = jwt.verify(token, secretKey) as jwt.JwtPayload;
     req.body.user_account_id = decoded.id;
+    // Des modifications vont être nécessaires,
+    // j'ai une PR déjà en cours.
+    // La ligne 108 sera supprimé.
+    // (id étant déjà dispo ligne 112)
+    req.user = {
+      id: decoded.id,
+      is_admin: decoded.isAdmin,
+      email: decoded.email,
+      firstname: decoded.firstname,
+      lastname: decoded.lastname,
+    };
     next();
   } catch (err) {
     res.status(401).json({ error: "Invalid token" });


### PR DESCRIPTION
## Summary of Changes

This pull request introduces new administrative functionalities to the backend, including the ability to manage artworks and enforce admin-specific access controls. It also adds a new admin user to the database and updates the authentication logic to include admin-related properties.

### Administrative Features

**New admin repository and actions**
- Added `AdminRepository` in `server/src/modules/admin/adminRepository.ts` to provide methods for fetching and deleting artworks, users, categories, purchases, news, and events.
- Introduced `adminActions` in `server/src/modules/admin/adminActions.ts` to handle API endpoints for browsing and deleting artworks.

**Admin-specific API route**
- Added a new route in `server/src/router.ts` to allow authenticated admin users to delete artworks (`/api/admin/artwork/:id`). This route includes middleware for user authentication and admin authorization.

### Authentication and Authorization

**Admin authorization middleware**
- Created `adminAuth` middleware in `server/src/utils/admin.ts` to restrict access to certain routes based on the `is_admin` property of the authenticated user.

**Enhanced user authentication**
- Updated `authenticateUser` middleware in `server/src/utils/auth.ts` to include additional user properties (`is_admin`, `email`, `firstname`, `lastname`) in the `req.user` object.

### Database Changes

**Added admin user**
- Inserted a new admin user into the `user_account` table in `server/database/schema.sql` with the email `admin@creanova.com`.