### PR TITLE
Us 33 - Feat - Delete artwork admin

### DIFF
--- a/client/src/pages/AdminDashboard/AdminDashboard.css
+++ b/client/src/pages/AdminDashboard/AdminDashboard.css
@@ -1,0 +1,9 @@
+.admin-dashboard {
+  .admin-dashboard-artwork-section {
+    img {
+      width: 70px;
+      height: 70px;
+      object-fit: cover;
+    }
+  }
+}

--- a/client/src/pages/AdminDashboard/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard/AdminDashboard.tsx
@@ -1,10 +1,13 @@
+import ArtworksSection from "./ArtworksSection";
 import UsersSection from "./UsersSection";
+import "./AdminDashboard.css";
 
 function AdminDashboard() {
   return (
-    <main>
-      <h1>test</h1>
+    <main className="admin-dashboard">
+      <h1>Dashboard</h1>
       <UsersSection />
+      <ArtworksSection />
     </main>
   );
 }

--- a/client/src/pages/AdminDashboard/ArtworksSection.tsx
+++ b/client/src/pages/AdminDashboard/ArtworksSection.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
-
+interface Artwork {
+  id: number;
+  title: string;
+  image: string;
+  price: number;
+  sold: boolean;
+}
 function ArtworksSection() {
-  const [artworks, setArtworks] = useState();
+  const [artworks, setArtworks] = useState<Artwork[]>([]);
 
   useEffect(() => {
     fetch("http://localhost:3310/api/admin/artworks", {
@@ -11,13 +17,56 @@ function ArtworksSection() {
       .then((data) => {
         setArtworks(data);
       });
-  });
+  }, []);
+
+  const handleDelete = (id: number) => {
+    const confirmDelete = window.confirm(
+      "Êtes-vous sûr de vouloir supprimer cette oeuvre ?",
+    );
+    if (!confirmDelete) return;
+    fetch(`http://localhost:3310/api/admin/artwork/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+    }).then((res) => {
+      if (res.ok) {
+        setArtworks((prev) => prev.filter((u) => u.id !== id));
+      }
+    });
+  };
   if (!artworks) {
-    return <h1>prob</h1>;
+    return <h1>problem</h1>;
   }
   return (
-    <section>
-      <h1>test</h1>
+    <section className="admin-dashboard-artwork-section">
+      <h2>Oeuvre</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Titre</th>
+            <th>Image</th>
+            <th>Prix</th>
+            <th>Vendu</th>
+            <th>Supprimer</th>
+          </tr>
+        </thead>
+        <tbody>
+          {artworks.map((artwork) => (
+            <tr key={artwork.id}>
+              <td>{artwork.title}</td>
+              <td>
+                <img src={artwork.image} alt={artwork.title} />
+              </td>
+              <td>{artwork.price}</td>
+              {artwork.sold ? <td>Vendu</td> : <td>Disponible</td>}
+              <td>
+                <button type="button" onClick={() => handleDelete(artwork.id)}>
+                  Supprimer
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </section>
   );
 }

--- a/client/src/pages/AdminDashboard/ArtworksSection.tsx
+++ b/client/src/pages/AdminDashboard/ArtworksSection.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+function ArtworksSection() {
+  const [artworks, setArtworks] = useState();
+
+  useEffect(() => {
+    fetch("http://localhost:3310/api/admin/artworks", {
+      credentials: "include",
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setArtworks(data);
+      });
+  });
+  if (!artworks) {
+    return <h1>prob</h1>;
+  }
+  return (
+    <section>
+      <h1>test</h1>
+    </section>
+  );
+}
+export default ArtworksSection;

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -89,6 +89,12 @@ router.delete(
   admin.adminAuth,
   adminActions.deleteUser,
 );
+router.get(
+  "api/admin/artworks",
+  auth.authenticateUser,
+  admin.adminAuth,
+  adminActions.browseArtworks,
+);
 router.delete(
   "/api/admin/artwork/:id",
   auth.authenticateUser,

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -90,7 +90,7 @@ router.delete(
   adminActions.deleteUser,
 );
 router.get(
-  "api/admin/artworks",
+  "/api/admin/artworks",
   auth.authenticateUser,
   admin.adminAuth,
   adminActions.browseArtworks,


### PR DESCRIPTION
## Summary of Changes

This pull request adds a new "Artworks" management feature to the Admin Dashboard, enabling administrators to view, display, and delete artwork entries. Changes have been made on both the client and server sides, including UI components, API endpoints, and data handling logic.

## Frontend Changes

- **New `ArtworksSection` Component**: Introduced a component to fetch and display artworks in a table, with delete functionality. Uses `useEffect` and `useState` for data fetching and state management.  
  File: `client/src/pages/AdminDashboard/ArtworksSection.tsx`

- **Updated `AdminDashboard`**: Integrated `ArtworksSection` into the existing Admin Dashboard alongside `UsersSection`.
