### PR TITLE
added a deletion toast and changed the redirect after deletion

### DIFF
--- a/client/src/pages/ArtistArtworkDetailPage/ArtistArtworkDetailPage.tsx
+++ b/client/src/pages/ArtistArtworkDetailPage/ArtistArtworkDetailPage.tsx
@@ -1,13 +1,15 @@
 import { Link, useNavigate, useParams } from "react-router";
 import "./ArtistArtworkDetailPage.css";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../../hooks/useAuth";
+import { toast, ToastContainer } from "react-toastify";
 
 function ArtistArtworkDetailPage() {
   const [artwork, setArtwork] = useState<Artwork>();
   const { isLogged } = useAuth();
   const { userId, artworkId } = useParams();
   const navigate = useNavigate();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     fetch(`http://localhost:3310/api/artist/${userId}/artworks/${artworkId}`, {
@@ -22,11 +24,24 @@ function ArtistArtworkDetailPage() {
       credentials: "include",
       method: "delete",
     }).then((res) => {
-      if (res.status === 200) {
-        navigate("/");
+      if (res.ok) {
+        toast.success("Oeuvre supprimée avec succès !");
+        timeoutRef.current = setTimeout(() => {
+          navigate(`/collection/${userId}`);
+        }, 2000);
+      } else {
+        toast.error("Il y a eu un problème lors de la suppression.");
       }
     });
   };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   if (!artwork || !artwork.id) {
     return (
@@ -50,21 +65,24 @@ function ArtistArtworkDetailPage() {
   }
 
   return (
-    <main className="artist-artwork-detail-main">
-      <h1>{artwork.title}</h1>
-      <figure>
-        <img src={artwork.image} alt={artwork.title} />
-        <figcaption>{artwork.title}</figcaption>
-      </figure>
-      <article>
-        <Link to={`/artist/${userId}/artworks/${artwork.id}/edit`}>
-          <button type="button">Modifier</button>
-        </Link>
-        <button type="button" onClick={handleOnSubmit}>
-          Supprimer
-        </button>
-      </article>
-    </main>
+    <>
+      <main className="artist-artwork-detail-main">
+        <h1>{artwork.title}</h1>
+        <figure>
+          <img src={artwork.image} alt={artwork.title} />
+          <figcaption>{artwork.title}</figcaption>
+        </figure>
+        <article>
+          <Link to={`/artist/${userId}/artworks/${artwork.id}/edit`}>
+            <button type="button">Modifier</button>
+          </Link>
+          <button type="button" onClick={handleOnSubmit}>
+            Supprimer
+          </button>
+        </article>
+      </main>
+      <ToastContainer position="bottom-right" autoClose={3000} />
+    </>
   );
 }
 

--- a/client/src/pages/ArtistArtworkDetailPage/ArtistArtworkDetailPage.tsx
+++ b/client/src/pages/ArtistArtworkDetailPage/ArtistArtworkDetailPage.tsx
@@ -1,8 +1,8 @@
 import { Link, useNavigate, useParams } from "react-router";
 import "./ArtistArtworkDetailPage.css";
 import { useEffect, useRef, useState } from "react";
+import { ToastContainer, toast } from "react-toastify";
 import { useAuth } from "../../hooks/useAuth";
-import { toast, ToastContainer } from "react-toastify";
 
 function ArtistArtworkDetailPage() {
   const [artwork, setArtwork] = useState<Artwork>();


### PR DESCRIPTION
This pull request enhances the user experience on the `ArtistArtworkDetailPage` by adding toast notifications for feedback, improving navigation after artwork deletion, and ensuring proper cleanup of timeouts. The changes also include minor structural updates to the component.

### Enhancements to user experience:
   Enhancement | Description |
 |-------------|-------------|
 | **Added toast notifications** | Added toast notifications to provide feedback on the success or failure of artwork deletion using `react-toastify`. 
 | **Included a `ToastContainer` component** | Included a `ToastContainer` component to display the notifications at the bottom-right corner with an auto-close duration of 3 seconds. 

### Navigation improvements:
 | Improvement | Description |
 |-------------|-------------|
 | **Changed navigation after successful artwork deletion** | Changed navigation after successful artwork deletion to redirect to the user's collection page (`/collection/:userId`) instead of the root page, with a 2-second delay for better user experience. 

### Code quality and cleanup:
 | Update | Description |
 |--------|-------------|
 | **Added a `useRef` to manage the timeout** | Added a `useRef` to manage the timeout for delayed navigation and implemented a cleanup function in a `useEffect` to clear the timeout when the component unmounts. 

