### PR TITLE
link to the collection page

### DIFF
--- a/client/src/pages/EditArtworkPage/EditArtworkPage.tsx
+++ b/client/src/pages/EditArtworkPage/EditArtworkPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router";
+import { useEffect, useRef, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
 import { ToastContainer, toast } from "react-toastify";
 import { useAuth } from "../../hooks/useAuth";
 import "./EditArtworkPage.css";
@@ -7,8 +7,9 @@ import "./EditArtworkPage.css";
 function EditArtworkPage() {
   const [artwork, setArtwork] = useState<Artwork>();
   const { isLogged } = useAuth();
-
   const { userId, artworkId } = useParams();
+  const navigate = useNavigate();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     fetch(`http://localhost:3310/api/artist/${userId}/artworks/${artworkId}`)
@@ -33,6 +34,18 @@ function EditArtworkPage() {
       .then((res) => res.json())
       .then(() => {
         toast.success("Oeuvre modifiée !");
+        timeoutRef.current = setTimeout(() => {
+          navigate(`/collection/${userId}`);
+        }, 2000);
+
+        useEffect(() => {
+          return () => {
+            if (timeoutRef.current) {
+              clearTimeout(timeoutRef.current);
+            }
+          };
+        }, []);
+
         fetch(
           `http://localhost:3310/api/artist/${userId}/artworks/${artworkId}`,
           {


### PR DESCRIPTION
This pull request introduces improvements to the EditArtworkPage component in client/src/pages/EditArtworkPage/EditArtworkPage.tsx. 🛠️

The changes focus on:

Adding the useNavigate hook: Adding the useNavigate hook to enable programmatic navigation after a successful artwork update. The user is redirected to their collection page (/collection/${userId}) 2 seconds after a success notification is displayed. 🗺️

Introducing a useRef for the timeout: Introducing a useRef (timeoutRef) to store the timeout ID and implementing a cleanup function in a useEf to clear the timeout when the component is unmounted, thus preventing potential memory leaks. ⏰