### PR TITLE
US 42 - Feat - Edit artwork

### DIFF
--- a/client/src/pages/EditArtworkPage/EditArtworkPage.css
+++ b/client/src/pages/EditArtworkPage/EditArtworkPage.css
@@ -27,6 +27,27 @@
       height: 30px;
       background: #f5f8fa;
     }
+    section {
+      text-align: center;
+      img {
+        width: 20%;
+      }
+    }
+    #artwork-image {
+      display: none;
+    }
+    .file-label {
+      padding: 10px 24px;
+      background: #4caf50;
+      color: #fff;
+      border-radius: 8px;
+      cursor: pointer;
+      margin: 0 auto;
+      transition: background 0.2s;
+      &:hover {
+        background: #388e3c;
+      }
+    }
 
     textarea {
       padding: 0.5rem 1rem;
@@ -56,7 +77,7 @@
     background: var(--button-reg-log);
     color: var(--primary-color);
     font-size: 1.1rem;
-    margin: 0 auto;
+    margin: 16px auto 0 auto;
     transition: background 0.2s;
     &:hover {
       background: #183040;

--- a/client/src/pages/EditArtworkPage/EditArtworkPage.tsx
+++ b/client/src/pages/EditArtworkPage/EditArtworkPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { ToastContainer, toast } from "react-toastify";
 import { useAuth } from "../../hooks/useAuth";
@@ -10,7 +10,9 @@ function EditArtworkPage() {
   const { userId, artworkId } = useParams();
   const navigate = useNavigate();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  // const [file, setFile] = useState<File | undefined>();
+  const [file, setFile] = useState<File | undefined>();
+  const [previewImage, setPreviewImage] = useState<string>();
+
   useEffect(() => {
     fetch(`http://localhost:3310/api/artist/${userId}/artworks/${artworkId}`)
       .then((res) => res.json())
@@ -19,17 +21,44 @@ function EditArtworkPage() {
       });
   }, [userId, artworkId]);
 
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (selectedFile) {
+      if (selectedFile.size > 500 * 1024) {
+        toast.error("La taille de l'image ne doit pas être supérieur à 500ko");
+        e.target.value = "";
+        setFile(undefined);
+        setPreviewImage(undefined);
+        return;
+      }
+      setFile(selectedFile);
+      setPreviewImage(URL.createObjectURL(selectedFile));
+    }
+  };
+
   const handleOnSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const formObject = Object.fromEntries(formData.entries());
+    const formData = new FormData();
+    const target = e.currentTarget as HTMLFormElement;
+    formData.append(
+      "title",
+      (target.elements.namedItem("title") as HTMLInputElement).value,
+    );
+    formData.append(
+      "description",
+      (target.elements.namedItem("description") as HTMLTextAreaElement).value,
+    );
+    formData.append(
+      "price",
+      (target.elements.namedItem("price") as HTMLInputElement).value,
+    );
+    if (file) {
+      formData.append("image", file);
+    }
     fetch(`http://localhost:3310/api/artwork/${artworkId}`, {
       credentials: "include",
       method: "put",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(formObject),
+      body: formData,
     })
       .then((res) => res.json())
       .then(() => {
@@ -37,14 +66,6 @@ function EditArtworkPage() {
         timeoutRef.current = setTimeout(() => {
           navigate(`/collection/${userId}`);
         }, 2000);
-
-        useEffect(() => {
-          return () => {
-            if (timeoutRef.current) {
-              clearTimeout(timeoutRef.current);
-            }
-          };
-        }, []);
 
         fetch(
           `http://localhost:3310/api/artist/${userId}/artworks/${artworkId}`,
@@ -58,6 +79,14 @@ function EditArtworkPage() {
           });
       });
   };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   if (!artwork) {
     return (
@@ -101,10 +130,28 @@ function EditArtworkPage() {
               name="image"
               id="artwork-image"
               accept="image/png, image/jpeg, image/jpg"
+              onChange={handleFile}
             />
             <label htmlFor="artwork-image" className="file-label">
               Choisir une image
             </label>
+            {file ? (
+              <section>
+                <p>Nom : {file.name}</p>
+                <p>Taille : {file.size} bytes</p>
+                <img src={previewImage} alt="Prévisualisation" />
+              </section>
+            ) : (
+              artwork?.image && (
+                <section>
+                  <p>Image actuelle :</p>
+                  <img
+                    src={`http://localhost:3310/${artwork.image}`}
+                    alt="Prévisualition fichier actuel"
+                  />
+                </section>
+              )
+            )}
             <button type="submit">Modifier</button>
           </form>
         </section>

--- a/client/src/pages/EditArtworkPage/EditArtworkPage.tsx
+++ b/client/src/pages/EditArtworkPage/EditArtworkPage.tsx
@@ -10,7 +10,7 @@ function EditArtworkPage() {
   const { userId, artworkId } = useParams();
   const navigate = useNavigate();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-
+  // const [file, setFile] = useState<File | undefined>();
   useEffect(() => {
     fetch(`http://localhost:3310/api/artist/${userId}/artworks/${artworkId}`)
       .then((res) => res.json())
@@ -96,8 +96,15 @@ function EditArtworkPage() {
             />
             <label htmlFor="price"> Tarif:</label>
             <input type="text" name="price" defaultValue={artwork.price} />
-            <label htmlFor="image"> Image URL:</label>
-            <input type="text" name="image" defaultValue={artwork.image} />
+            <input
+              type="file"
+              name="image"
+              id="artwork-image"
+              accept="image/png, image/jpeg, image/jpg"
+            />
+            <label htmlFor="artwork-image" className="file-label">
+              Choisir une image
+            </label>
             <button type="submit">Modifier</button>
           </form>
         </section>

--- a/server/src/modules/artwork/artworkActions.ts
+++ b/server/src/modules/artwork/artworkActions.ts
@@ -141,18 +141,23 @@ const edit: RequestHandler = async (req, res, next) => {
       res.status(404).json("Artwork not found");
       return;
     }
-    if (artwork[0].user_account_id !== req.body.user_account_id) {
+    if (artwork[0].user_account_id !== req.user?.id) {
       res
         .status(403)
         .json("Unauthorized: You are not the owner of this artwork");
       return;
     }
 
+    let image = req.body.image;
+    if (!image || image === "" || typeof image !== "string") {
+      image = artwork[0].image;
+    }
+
     const newArtwork = {
       id: Number(req.params.id),
       title: req.body.title,
       description: req.body.description,
-      image: req.body.image,
+      image,
       price: req.body.price,
     };
     const result = await artworkRepository.update(newArtwork);

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -47,7 +47,13 @@ router.get(
 );
 router.get("/api/artwork/:id", artworkActions.readArtworkById);
 router.get("/api/artwork/:id/artist", artworkActions.readArtworkWithArtistById);
-router.put("/api/artwork/:id", auth.authenticateUser, artworkActions.edit);
+router.put(
+  "/api/artwork/:id",
+  auth.authenticateUser,
+  file.imageUpload,
+  file.appImage,
+  artworkActions.edit,
+);
 router.get(
   "/api/artist/:id/artworks",
   auth.authenticateUser,


### PR DESCRIPTION
## Summary of Changes

This pull request introduces enhancements to the `EditArtworkPage` functionality, including support for image uploads, improved file handling, and updates to the backend to process uploaded images. It also includes minor UI improvements and refactoring for better maintainability.

---

## Frontend Changes

**Image Upload Support**
- Added image upload functionality to the artwork edit form:
  - Handled file input with size validation (max 500 KB)
  - Displayed preview of the selected image (or fallback to existing image)
  - Used `FormData` to send the form data instead of JSON  

**Code Refactoring**
- Extracted timeout cleanup into a separate `useEffect`
- Added explicit type annotations in imports  

---

## Backend Changes

**Image Handling**
- Updated `edit` action to:
  - Accept uploaded images (if provided)
  - Fallback to existing image if no file is sent 

**Middleware Integration**
- Added `file.imageUpload` and `file.appImage` middleware to the `PUT /api/artworks/:id` route  