### PR TITLE
US - 43 - Add sold status handling and styling across multiple pages

### DIFF
--- a/client/src/pages/ArtworkDetailPage/ArtworkDetailPage.css
+++ b/client/src/pages/ArtworkDetailPage/ArtworkDetailPage.css
@@ -119,7 +119,9 @@
       display: block;
     }
   }
-
+  .is-sold {
+    justify-self: end;
+  }
   h2 {
     text-align: center;
     font-size: 2rem;

--- a/client/src/pages/ArtworkDetailPage/ArtworkDetailPage.tsx
+++ b/client/src/pages/ArtworkDetailPage/ArtworkDetailPage.tsx
@@ -41,13 +41,17 @@ function ArtworkDetailPage() {
                 <span className="tags">{artwork.tags}</span>
               </div>
               <span className="price">{artwork.price}€</span>
-              <button
-                className="add-to-cart"
-                type="button"
-                aria-label="Ajouter au panier"
-              >
-                <img src="/img/shopping-cart-white-icon.png" alt="" />
-              </button>
+              {artwork.sold ? (
+                <span className="is-sold">Vendu</span>
+              ) : (
+                <button
+                  className="add-to-cart"
+                  type="button"
+                  aria-label="Ajouter au panier"
+                >
+                  <img src="/img/shopping-cart-white-icon.png" alt="" />
+                </button>
+              )}
             </figcaption>
           </Link>
         </figure>

--- a/client/src/pages/CollectionPage/CollectionPage.css
+++ b/client/src/pages/CollectionPage/CollectionPage.css
@@ -94,6 +94,8 @@
       background: rgba(0, 0, 0, 0.5);
       backdrop-filter: blur(4px);
       padding: 8px 16px;
+      display: flex;
+      justify-content: space-between;
     }
   }
   @media screen and (min-width: 375px) {

--- a/client/src/pages/CollectionPage/CollectionPage.tsx
+++ b/client/src/pages/CollectionPage/CollectionPage.tsx
@@ -54,7 +54,10 @@ function CollectionPage() {
         <figure key={item.id}>
           <Link to={`/artist/${id}/artwork/${item.id}`}>
             <img src={`http://localhost:3310/${item.image}`} alt={item.title} />
-            <figcaption>{item.title}</figcaption>
+            <figcaption>
+              {item.title}
+              {item.sold ? <span>Vendu</span> : ""}
+            </figcaption>
           </Link>
         </figure>
       ))}

--- a/client/src/pages/FavoritePage/FavoritePage.css
+++ b/client/src/pages/FavoritePage/FavoritePage.css
@@ -110,6 +110,9 @@
       display: block;
     }
   }
+  .is-sold {
+    justify-self: end;
+  }
 }
 
 /*DESKTOP*/

--- a/client/src/pages/FavoritePage/FavoritePage.tsx
+++ b/client/src/pages/FavoritePage/FavoritePage.tsx
@@ -55,13 +55,17 @@ function FavoritePage() {
                 </p>
               </div>
               <span className="price">{item.price}€</span>
-              <button
-                className="add-to-cart"
-                type="button"
-                aria-label="Ajouter au panier"
-              >
-                <img src="/img/shopping-cart-white-icon.png" alt="shop" />
-              </button>
+              {item.sold ? (
+                <span className="is-sold">Vendu</span>
+              ) : (
+                <button
+                  className="add-to-cart"
+                  type="button"
+                  aria-label="Ajouter au panier"
+                >
+                  <img src="/img/shopping-cart-white-icon.png" alt="" />
+                </button>
+              )}
             </figcaption>
           </figure>
         ))}

--- a/client/src/pages/GalleryPage/GalleryPage.css
+++ b/client/src/pages/GalleryPage/GalleryPage.css
@@ -125,6 +125,9 @@
         display: block;
       }
     }
+    .is-sold {
+      justify-self: end;
+    }
   }
 }
 

--- a/client/src/pages/GalleryPage/GalleryPage.tsx
+++ b/client/src/pages/GalleryPage/GalleryPage.tsx
@@ -89,22 +89,26 @@ function GalleryPage() {
                 <div className="tags">{artwork.tags}</div>
               </div>
               <span className="price">{artwork.price}€</span>
-              <button
-                className="add-to-cart"
-                type="button"
-                aria-label="Ajouter au panier"
-                onClick={() =>
-                  addToCart({
-                    id: artwork.id,
-                    title: artwork.title,
-                    image: artwork.image,
-                    price: Number(artwork.price),
-                    artist_name: artwork.artist_name,
-                  })
-                }
-              >
-                <img src="/img/shopping-cart-white-icon.png" alt="" />
-              </button>
+              {artwork.sold ? (
+                <span className="is-sold">Vendu</span>
+              ) : (
+                <button
+                  className="add-to-cart"
+                  type="button"
+                  aria-label="Ajouter au panier"
+                  onClick={() =>
+                    addToCart({
+                      id: artwork.id,
+                      title: artwork.title,
+                      image: artwork.image,
+                      price: Number(artwork.price),
+                      artist_name: artwork.artist_name,
+                    })
+                  }
+                >
+                  <img src="/img/shopping-cart-white-icon.png" alt="" />
+                </button>
+              )}
             </figcaption>
           </figure>
         ))}

--- a/client/src/types/Artwork.ts
+++ b/client/src/types/Artwork.ts
@@ -10,4 +10,5 @@ interface Artwork {
   artist_image: string;
   user_account_id: number;
   tags: string;
+  sold?: boolean;
 }

--- a/client/src/types/Favorite.ts
+++ b/client/src/types/Favorite.ts
@@ -6,4 +6,5 @@ interface Favorite {
   firstname: string;
   lastname: string;
   artwork_id: number;
+  sold: boolean;
 }

--- a/server/src/modules/artwork/artworkRepository.ts
+++ b/server/src/modules/artwork/artworkRepository.ts
@@ -22,6 +22,7 @@ class ArtworkRepository {
       a.image,
       a.title,
       a.price,
+      a.sold,
       CONCAT(ua.firstname, ' ', ua.lastname) AS artist_name,
       GROUP_CONCAT(DISTINCT CASE WHEN c.name <> ? THEN c.name END SEPARATOR ' - ') AS tags
    FROM artwork AS a


### PR DESCRIPTION
## Summary of Changes

This pull request adds support for displaying the **"sold"** status of artworks throughout the application. It includes updates to the UI, CSS, TypeScript interfaces, and backend SQL queries to ensure the label appears consistently across pages.

---

## Frontend Updates

**Artwork Detail Page**
- Displays `"Vendu"` badge for sold artworks
- Introduced `.is-sold` CSS class for alignment and layout  

**Collection Page**
- Shows `"Vendu"` in each artwork’s `figcaption`
- Improved layout using `justify-content: space-between`  

**Favorite Page**
- Added `"Vendu"` label for sold artworks
- Styled using the `.is-sold` class for consistent alignment  

**Gallery Page**
- Displays `"Vendu"` label on sold artworks
- Layout adjusted with `.is-sold` styling  
- 
---

## Backend 

**Artwork Repository**
- Updated SQL query to fetch `sold` status from the `artwork` table  